### PR TITLE
Use valid url value in library.properties

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,5 +8,3 @@ image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml"]
 
 Allows you to read accelerometer and gyroscope values of the LSM6DSOX IMU on your Arduino Nano RP2040 Connect.
-
-For more information about this library please visit us at https://www.arduino.cc/en/Reference/{repository-name}

--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Arduino <info@arduino.cc>
 sentence=Allows you to read the accelerometer and gyroscope values from the LSM6DSOX IMU on your Arduino Nano RP2040 Connect.
 paragraph=
 category=Sensors
-url=https://www.arduino.cc/en/Reference/Arduino_LSM6DSOX
+url=https://github.com/arduino-libraries/Arduino_LSM6DSOX
 architectures=*
 includes=Arduino_LSM6DSOX.h


### PR DESCRIPTION
The previous library.properties `url` field value perhaps anticipates an eventual reference page for the library, but at
present there is no such page, so it provides a poor experience for the user. Better to point them to a site that exists
now. Then update at such time as a reference is created.