### PR TITLE
Add automatic selection of Wire/SPI interface

### DIFF
--- a/src/LSM6DSOX.cpp
+++ b/src/LSM6DSOX.cpp
@@ -265,4 +265,8 @@ int LSM6DSOXClass::writeRegister(uint8_t address, uint8_t value)
   return 1;
 }
 
+#ifdef LSM6DS_DEFAULT_SPI
+LSM6DSOXClass IMU(LSM6DS_DEFAULT_SPI, PIN_SPI_SS1, LSM6DS_INT);
+#else
 LSM6DSOXClass IMU(Wire, LSM6DSOX_ADDRESS);
+#endif


### PR DESCRIPTION
This PR allows to create the `IMU` object with SPI interface if `LSM6DS_DEFAULT_SPI` and `LSM6DS_INT` are defined in the core. 
If the `LSM6DS_DEFAULT_SPI` define is not present, the IMU will use the I2C, as it was before.