### PR TITLE
Return LSM6DSOX temperature as float

### DIFF
--- a/examples/SimpleTemperature/SimpleTemperature.ino
+++ b/examples/SimpleTemperature/SimpleTemperature.ino
@@ -32,11 +32,16 @@ void loop()
 {
   if (IMU.temperatureAvailable())
   {
-    float temperature_deg = 0;
-    IMU.readTemperature(temperature_deg);
+    int temperature_int = 0;
+    float temperature_float = 0;
+    IMU.readTemperature(temperature_int);
+    IMU.readTemperatureFloat(temperature_float);
 
     Serial.print("LSM6DSOX Temperature = ");
-    Serial.print(temperature_deg);
+    Serial.print(temperature_int);
+    Serial.print(" (");
+    Serial.print(temperature_float);
+    Serial.print(")");
     Serial.println(" °C");
   }
 }

--- a/examples/SimpleTemperature/SimpleTemperature.ino
+++ b/examples/SimpleTemperature/SimpleTemperature.ino
@@ -32,7 +32,7 @@ void loop()
 {
   if (IMU.temperatureAvailable())
   {
-    int temperature_deg = 0;
+    float temperature_deg = 0;
     IMU.readTemperature(temperature_deg);
 
     Serial.print("LSM6DSOX Temperature = ");

--- a/src/LSM6DSOX.cpp
+++ b/src/LSM6DSOX.cpp
@@ -174,7 +174,7 @@ int LSM6DSOXClass::gyroscopeAvailable()
   return 0;
 }
 
-int LSM6DSOXClass::readTemperature(int & temperature_deg)
+int LSM6DSOXClass::readTemperature(float& temperature_deg)
 {
   /* Read the raw temperature from the sensor. */
   int16_t temperature_raw = 0;
@@ -187,7 +187,7 @@ int LSM6DSOXClass::readTemperature(int & temperature_deg)
   static int const TEMPERATURE_LSB_per_DEG = 256;
   static int const TEMPERATURE_OFFSET_DEG = 25;
 
-  temperature_deg = (static_cast<int>(temperature_raw) / TEMPERATURE_LSB_per_DEG) + TEMPERATURE_OFFSET_DEG;
+  temperature_deg = (static_cast<float>(temperature_raw) / TEMPERATURE_LSB_per_DEG) + TEMPERATURE_OFFSET_DEG;
 
   return 1;
 }

--- a/src/LSM6DSOX.cpp
+++ b/src/LSM6DSOX.cpp
@@ -174,7 +174,17 @@ int LSM6DSOXClass::gyroscopeAvailable()
   return 0;
 }
 
-int LSM6DSOXClass::readTemperature(float& temperature_deg)
+int LSM6DSOXClass::readTemperature(int& temperature_deg)
+{
+  float temperature_float = 0;
+  readTemperatureFloat(temperature_float);
+
+  temperature_deg = static_cast<int>(temperature_float);
+
+  return 1;
+}
+
+int LSM6DSOXClass::readTemperatureFloat(float& temperature_deg)
 {
   /* Read the raw temperature from the sensor. */
   int16_t temperature_raw = 0;

--- a/src/LSM6DSOX.h
+++ b/src/LSM6DSOX.h
@@ -42,7 +42,7 @@ class LSM6DSOXClass {
     int gyroscopeAvailable(); // Check for available data from gyroscope
 
     // Temperature
-    int readTemperature(int & temperature_deg);
+    int readTemperature(float& temperature_deg);
     int temperatureAvailable();
 
   private:

--- a/src/LSM6DSOX.h
+++ b/src/LSM6DSOX.h
@@ -42,7 +42,8 @@ class LSM6DSOXClass {
     int gyroscopeAvailable(); // Check for available data from gyroscope
 
     // Temperature
-    int readTemperature(float& temperature_deg);
+    int readTemperature(int& temperature_deg);
+    int readTemperatureFloat(float& temperature_deg);
     int temperatureAvailable();
 
   private:


### PR DESCRIPTION
Update temperature API to return temperature with greater precision as `float`.
This addresses [this comment](https://github.com/arduino-libraries/Arduino_LSM6DSOX/issues/7#issuecomment-908078563) in #7.