### PR TITLE
readTemperature now returns float.

### DIFF
--- a/examples/SimpleTemperature/SimpleTemperature.ino
+++ b/examples/SimpleTemperature/SimpleTemperature.ino
@@ -32,7 +32,7 @@ void loop()
 {
   if (IMU.temperatureAvailable())
   {
-    int temperature_deg = 0;
+    float temperature_deg = 0.0;
     IMU.readTemperature(temperature_deg);
 
     Serial.print("LSM6DSOX Temperature = ");

--- a/src/LSM6DSOX.h
+++ b/src/LSM6DSOX.h
@@ -42,7 +42,7 @@ class LSM6DSOXClass {
     int gyroscopeAvailable(); // Check for available data from gyroscope
 
     // Temperature
-    int readTemperature(int & temperature_deg);
+    int readTemperature(float & temperature_deg);
     int temperatureAvailable();
 
   private:


### PR DESCRIPTION
I've re-written readTemperature according to the datasheet. It seems the 16 bit temperature ADC stores bits to two separate 8 bit spaces. Converting them to signed int and again to float with temperature range, -40 to 85, then adjusting with + 25.0 seems to be yielding a close enough temperature.