### PR TITLE
Fix incorrect error handling

### DIFF
--- a/src/LSM6DSOX.cpp
+++ b/src/LSM6DSOX.cpp
@@ -117,7 +117,7 @@ int LSM6DSOXClass::readAcceleration(float& x, float& y, float& z)
 {
   int16_t data[3];
 
-  if (!readRegisters(LSM6DSOX_OUTX_L_XL, (uint8_t*)data, sizeof(data))) {
+  if (readRegisters(LSM6DSOX_OUTX_L_XL, (uint8_t*)data, sizeof(data)) != 1) {
     x = NAN;
     y = NAN;
     z = NAN;
@@ -150,7 +150,7 @@ int LSM6DSOXClass::readGyroscope(float& x, float& y, float& z)
 {
   int16_t data[3];
 
-  if (!readRegisters(LSM6DSOX_OUTX_L_G, (uint8_t*)data, sizeof(data))) {
+  if (readRegisters(LSM6DSOX_OUTX_L_G, (uint8_t*)data, sizeof(data)) != 1) {
     x = NAN;
     y = NAN;
     z = NAN;


### PR DESCRIPTION
This pull request updates the error handling logic in the sensor data reading functions to more accurately check the result of the `readRegisters` calls. Instead of relying on a boolean return value, the functions now explicitly check if the result equals 1 to determine success.

Fixes #43 