### PR TITLE
Remove automatic bus teardown

### DIFF
--- a/src/LSM6DSOX.cpp
+++ b/src/LSM6DSOX.cpp
@@ -80,7 +80,6 @@ int LSM6DSOXClass::begin()
   }
 
   if (!(readRegister(LSM6DSOX_WHO_AM_I_REG) == 0x6C || readRegister(LSM6DSOX_WHO_AM_I_REG) == 0x69)) {
-    end();
     return 0;
   }
 
@@ -103,13 +102,11 @@ int LSM6DSOXClass::begin()
 void LSM6DSOXClass::end()
 {
   if (_spi != NULL) {
-    _spi->end();
     digitalWrite(_csPin, LOW);
     pinMode(_csPin, INPUT);
   } else {
     writeRegister(LSM6DSOX_CTRL2_G, 0x00);
     writeRegister(LSM6DSOX_CTRL1_XL, 0x00);
-    _wire->end();
   }
 }
 


### PR DESCRIPTION
This PR prevents the library from inadvertently tearing down shared I2C and SPI buses, which previously caused other connected sensors to fail. The `_wire->end()` and `_spi->end()` calls have been removed from the `end()` method, as well as the `end()` call triggered during a failed "WHO AM I" check in `begin().` The sensor is still properly placed into power-down mode via its control registers, but leaving the shared hardware interfaces active ensures seamless operation in multi-device environments.